### PR TITLE
[PAXRUNNER-454] Support Felix 4.6.0, 4.6.1, 5.0.0, 5.0.1, 5.2.0 and 5.4.0

### DIFF
--- a/pax-runner-platform-felix/src/main/java/org/ops4j/pax/runner/platform/felix/internal/Activator.java
+++ b/pax-runner-platform-felix/src/main/java/org/ops4j/pax/runner/platform/felix/internal/Activator.java
@@ -79,6 +79,12 @@ public final class Activator
             new FelixPlatformBuilderF160( bundleContext, "4.2.1" ),
             new FelixPlatformBuilderF160( bundleContext, "4.4.0" ),
             new FelixPlatformBuilderF160( bundleContext, "4.4.1" ),
+            new FelixPlatformBuilderF160( bundleContext, "4.6.0" ),
+            new FelixPlatformBuilderF160( bundleContext, "4.6.1" ),
+            new FelixPlatformBuilderF160( bundleContext, "5.0.0" ),
+            new FelixPlatformBuilderF160( bundleContext, "5.0.1" ),
+            new FelixPlatformBuilderF160( bundleContext, "5.2.0" ),
+            new FelixPlatformBuilderF160( bundleContext, "5.4.0" ),
             new FelixPlatformBuilderSnapshot( bundleContext )
         };
     }

--- a/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-4.6.0.xml
+++ b/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-4.6.0.xml
@@ -1,0 +1,45 @@
+<platform>
+
+    <name>Felix 4.6.0</name>
+    <system>link:classpath:runner-links/org.apache.felix.main-4.6.0.link</system>
+
+    <packages>
+        org.osgi.framework;version="1.8",
+        org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",
+        org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",
+        org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",
+        org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",
+        org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",
+        org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",
+        org.osgi.resource;version="1.0",
+        org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",
+        org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",
+        org.osgi.service.url;version="1.0",
+        org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",
+        org.osgi.dto;version="1.0"
+    </packages>
+
+    <profile name="minimal" default="true"/>
+
+    <profile name="tui" extends="minimal">
+        <bundle>
+            <name>Apache Felix Gogo Command (0.14.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.command-0.14.0.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Runtime (0.12.1)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.runtime-0.12.1.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Shell (0.10.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.shell-0.10.0.link</url>
+        </bundle>
+    </profile>
+
+</platform>

--- a/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-4.6.1.xml
+++ b/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-4.6.1.xml
@@ -1,0 +1,45 @@
+<platform>
+
+    <name>Felix 4.6.1</name>
+    <system>link:classpath:runner-links/org.apache.felix.main-4.6.1.link</system>
+
+    <packages>
+        org.osgi.framework;version="1.8",
+        org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",
+        org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",
+        org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",
+        org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",
+        org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",
+        org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",
+        org.osgi.resource;version="1.0",
+        org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",
+        org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",
+        org.osgi.service.url;version="1.0",
+        org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",
+        org.osgi.dto;version="1.0"
+    </packages>
+
+    <profile name="minimal" default="true"/>
+
+    <profile name="tui" extends="minimal">
+        <bundle>
+            <name>Apache Felix Gogo Command (0.14.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.command-0.14.0.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Runtime (0.12.1)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.runtime-0.12.1.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Shell (0.10.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.shell-0.10.0.link</url>
+        </bundle>
+    </profile>
+
+</platform>

--- a/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.0.0.xml
+++ b/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.0.0.xml
@@ -1,0 +1,46 @@
+<platform>
+
+    <name>Felix 5.0.0</name>
+    <system>link:classpath:runner-links/org.apache.felix.main-5.0.0.link</system>
+
+    <packages>
+        org.osgi.framework;version="1.8",
+        org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",
+        org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",
+        org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",
+        org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",
+        org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",
+        org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",
+        org.osgi.resource;version="1.0",
+        org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",
+        org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",
+        org.osgi.service.url;version="1.0",
+        org.osgi.service.resolver;version="1.0";uses:="org.osgi.resource",
+        org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",
+        org.osgi.dto;version="1.0"
+    </packages>
+
+    <profile name="minimal" default="true"/>
+
+    <profile name="tui" extends="minimal">
+        <bundle>
+            <name>Apache Felix Gogo Command (0.14.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.command-0.14.0.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Runtime (0.16.2)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.runtime-0.16.2.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Shell (0.10.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.shell-0.10.0.link</url>
+        </bundle>
+    </profile>
+
+</platform>

--- a/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.0.1.xml
+++ b/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.0.1.xml
@@ -1,0 +1,46 @@
+<platform>
+
+    <name>Felix 5.0.1</name>
+    <system>link:classpath:runner-links/org.apache.felix.main-5.0.1.link</system>
+
+    <packages>
+        org.osgi.framework;version="1.8",
+        org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",
+        org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",
+        org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",
+        org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",
+        org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",
+        org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",
+        org.osgi.resource;version="1.0",
+        org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",
+        org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",
+        org.osgi.service.url;version="1.0",
+        org.osgi.service.resolver;version="1.0";uses:="org.osgi.resource",
+        org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",
+        org.osgi.dto;version="1.0"
+    </packages>
+
+    <profile name="minimal" default="true"/>
+
+    <profile name="tui" extends="minimal">
+        <bundle>
+            <name>Apache Felix Gogo Command (0.14.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.command-0.14.0.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Runtime (0.16.2)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.runtime-0.16.2.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Shell (0.10.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.shell-0.10.0.link</url>
+        </bundle>
+    </profile>
+
+</platform>

--- a/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.2.0.xml
+++ b/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.2.0.xml
@@ -1,0 +1,46 @@
+<platform>
+
+    <name>Felix 5.2.0</name>
+    <system>link:classpath:runner-links/org.apache.felix.main-5.2.0.link</system>
+
+    <packages>
+        org.osgi.framework;version="1.8",
+        org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",
+        org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",
+        org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",
+        org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",
+        org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",
+        org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",
+        org.osgi.resource;version="1.0",
+        org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",
+        org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",
+        org.osgi.service.url;version="1.0",
+        org.osgi.service.resolver;version="1.0";uses:="org.osgi.resource",
+        org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",
+        org.osgi.dto;version="1.0"
+    </packages>
+
+    <profile name="minimal" default="true"/>
+
+    <profile name="tui" extends="minimal">
+        <bundle>
+            <name>Apache Felix Gogo Command (0.14.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.command-0.14.0.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Runtime (0.16.2)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.runtime-0.16.2.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Shell (0.10.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.shell-0.10.0.link</url>
+        </bundle>
+    </profile>
+
+</platform>

--- a/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.4.0.xml
+++ b/pax-runner-platform-felix/src/main/resources/META-INF/platform-felix/definition-5.4.0.xml
@@ -1,0 +1,46 @@
+<platform>
+
+    <name>Felix 5.4.0</name>
+    <system>link:classpath:runner-links/org.apache.felix.main-5.4.0.link</system>
+
+    <packages>
+        org.osgi.framework;version="1.8",
+        org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",
+        org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",
+        org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",
+        org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",
+        org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",
+        org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",
+        org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",
+        org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",
+        org.osgi.resource;version="1.0",
+        org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",
+        org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",
+        org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",
+        org.osgi.service.url;version="1.0",
+        org.osgi.service.resolver;version="1.0";uses:="org.osgi.resource",
+        org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",
+        org.osgi.dto;version="1.0"
+    </packages>
+
+    <profile name="minimal" default="true"/>
+
+    <profile name="tui" extends="minimal">
+        <bundle>
+            <name>Apache Felix Gogo Command (0.16.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.command-0.16.0.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Runtime (0.16.2)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.runtime-0.16.2.link</url>
+        </bundle>
+        <bundle>
+            <name>Apache Felix Gogo Shell (0.12.0)</name>
+            <url>link:classpath:runner-links/org.apache.felix.gogo.shell-0.12.0.link</url>
+        </bundle>
+    </profile>
+
+</platform>

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.command-0.14.0.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.command-0.14.0.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.gogo.command/0.14.0

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.command-0.16.0.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.command-0.16.0.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.gogo.command/0.16.0

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.runtime-0.12.1.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.runtime-0.12.1.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.gogo.runtime/0.12.1

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.runtime-0.16.2.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.runtime-0.16.2.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.gogo.runtime/0.16.2

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.shell-0.12.0.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.gogo.shell-0.12.0.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.gogo.shell/0.12.0

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-4.6.0.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-4.6.0.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.main/4.6.0

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-4.6.1.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-4.6.1.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.main/4.6.1

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.0.0.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.0.0.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.main/5.0.0

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.0.1.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.0.1.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.main/5.0.1

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.2.0.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.2.0.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.main/5.2.0

--- a/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.4.0.link
+++ b/pax-runner-platform-felix/src/main/resources/runner-links/org.apache.felix.main-5.4.0.link
@@ -1,0 +1,1 @@
+mvn:org.apache.felix/org.apache.felix.main/5.4.0

--- a/pax-runner/src/main/resources/META-INF/runner.properties
+++ b/pax-runner/src/main/resources/META-INF/runner.properties
@@ -142,6 +142,12 @@ platform.felix.4.2.0=org.ops4j.pax.runner.platform.felix.internal.Activator
 platform.felix.4.2.1=org.ops4j.pax.runner.platform.felix.internal.Activator
 platform.felix.4.4.0=org.ops4j.pax.runner.platform.felix.internal.Activator
 platform.felix.4.4.1=org.ops4j.pax.runner.platform.felix.internal.Activator
+platform.felix.4.6.0=org.ops4j.pax.runner.platform.felix.internal.Activator
+platform.felix.4.6.1=org.ops4j.pax.runner.platform.felix.internal.Activator
+platform.felix.5.0.0=org.ops4j.pax.runner.platform.felix.internal.Activator
+platform.felix.5.0.1=org.ops4j.pax.runner.platform.felix.internal.Activator
+platform.felix.5.2.0=org.ops4j.pax.runner.platform.felix.internal.Activator
+platform.felix.5.4.0=org.ops4j.pax.runner.platform.felix.internal.Activator
 platform.felix.SNAPSHOT=org.ops4j.pax.runner.platform.felix.internal.Activator
 # Knopflerfish
 platform.knopflerfish.2.0.0=org.ops4j.pax.runner.platform.knopflerfish.internal.Activator
@@ -187,7 +193,7 @@ default.scanners=scanner.bundle,scanner.composite,scanner.dir,scanner.features,s
 # default platfom
 default.platform=platform.felix
 # default felix platform version
-default.platform.felix.version=4.4.1
+default.platform.felix.version=5.4.0
 # default equinox platform version
 default.platform.equinox.version=3.8.2
 # default knopflerfish platform version


### PR DESCRIPTION
Please pull Felix support up to 5.4.0 (current release).
I also made 5.4.0 the default version.
The packages section in the definition-*.xml's is taken directly from the MANIFEST.MF's of the corresponding Felix releases. It contains more information than older xml's (the "uses" part), but that seems to work.
I only tested with 5.4.0.

Thanks !